### PR TITLE
Code clean-up to meet linux kernel coding standards and get clean pass with checkpatch

### DIFF
--- a/thinkpad-wmi-master/drivers/platform/x86/thinklmi.h
+++ b/thinkpad-wmi-master/drivers/platform/x86/thinklmi.h
@@ -1,19 +1,24 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#ifndef _THINK_LMI_H_
+#define _THINK_LMI_H_
+
 #include <linux/ioctl.h>
 
-#define MAXCOUNT 15
-#define MAXLEN 35
- 
+#define TLMI_SETTINGS_MAXCNT 15
+#define TLMI_SETTINGS_MAXLEN 35
+
 typedef struct
 {
-    char  settings[MAXCOUNT][MAXLEN];
-    int settings_count;
-    int count;
-} query_arg_t;
- 
-#define THINKLMI_GET_SETTINGS _IOR('q', 1, query_arg_t *)
-#define THINKLMI_GET_SETTINGS_STRINGS _IOWR('s', 2, query_arg_t *)
+	char settings[TLMI_SETTINGS_MAXCNT][TLMI_SETTINGS_MAXLEN];
+	int  settings_count;
+	int  count;
+} tlmi_query_arg_t;
+
+#define THINKLMI_GET_SETTINGS _IOR('q', 1, tlmi_query_arg_t *)
+#define THINKLMI_GET_SETTINGS_STRINGS _IOWR('s', 2, tlmi_query_arg_t *)
 #define THINKLMI_SET_SETTING _IOW('t', 1, char *)
 #define THINKLMI_SHOW_SETTING _IOWR('u',1, char *)
 
-
+#endif /* !_THINK_LMI_H_ */
 


### PR DESCRIPTION
Hi Sugu,

I did some code clean up to get this more ready for review - have a look and see what you think.

Most of it was just addressing warnings and errors when running the checkpatch kernel script - there were pieces that weren't up to kernel coding standards (placement of spaces and brackets, 80 col lines, etc)

I also replaced the raw_copy_from/to_user functions with the regular copy_from/to_user functions. Was there a reason you were using the raw ones? I don't think you should use them unless there is a good reason.

The other major change was to make it so it compiled with the latest 5.5 kernel. Some of the debugfs functions had changed a bit.

I still need to do more review. For instance I'm pretty sure the chardev is not destroyed cleanly if the module is removed. But hopefully this is a good first pass.

Note - I really wanted to rename thinklmi.h to think-lmi.h but I restrained myself. Can we change it? It just bugs me having the c and h file different :)

Holler if any questions
mark